### PR TITLE
Improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
 	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
 	<title>Xenoblade Data Hub</title>
 	<link href="/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 	<style>
@@ -43,35 +44,40 @@
   </head>
   <body>
 	<div class="container-fluid py-4 px-5">
-		<header class="pb-3 mb-4 d-flex justify-content-between">
-			<a href="/" class="d-flex align-items-center text-white text-decoration-none">
-				<img src="/images/xc1_icon.svg" width="32"/>
-				<span class="fs-4 px-2">Xenoblade Data Hub</span>
-			</a>
-			<span class="text-center">
-			Last update: February 11, 2024<br/>
-			<a href="https://github.com/xenobladedata/xenobladedata.github.io/commits/master" target="_blank">View update history on GitHub</a>
-			</span>
+		<header class="pb-3 mb-4 row">
+			<div class="col col-12 col-md-auto">
+				<a href="/" class="d-flex align-items-center text-white text-decoration-none">
+					<img src="/images/xc1_icon.svg" width="32"/>
+					<span class="fs-4 px-2">Xenoblade Data Hub</span>
+				</a>
+			</div>
+			<!-- Align left on small displays, align right on larger displays -->
+			<div class="col text-md-end">
+				<span class="text-center">
+				Last update: February 11, 2024<br/>
+				<a href="https://github.com/xenobladedata/xenobladedata.github.io/commits/master" target="_blank">View update history on GitHub</a>
+				</span>
+			</div>
 		</header>
 		<div class="d-flex justify-content-center">
-			<ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
-			  <li class="nav-item" role="presentation">
-				<button class="nav-link active" id="pills-xc-tab" data-bs-toggle="pill" data-bs-target="#pills-xc" type="button" role="tab" aria-controls="pills-xc" aria-selected="true"><img src="/images/xc1_icon.svg" width="32"/><img src="/images/xcde_icon.svg" width="32"/></button>
+			<ul class="nav nav-pills mb-3 justify-content-center row" id="pills-tab" role="tablist">
+			  <li class="nav-item col col-6 col-md-auto" role="presentation">
+				<button class="nav-link active w-100 d-flex" id="pills-xc-tab" data-bs-toggle="pill" data-bs-target="#pills-xc" type="button" role="tab" aria-controls="pills-xc" aria-selected="true"><img src="/images/xc1_icon.svg" width="32"/><img src="/images/xcde_icon.svg" width="32"/></button>
 			  </li>
-			  <li class="nav-item" role="presentation">
-				<button class="nav-link" id="pills-xcx-tab" data-bs-toggle="pill" data-bs-target="#pills-xcx" type="button" role="tab" aria-controls="pills-xcx" aria-selected="false"><img src="/images/xcx_icon.svg" width="32"/></button>
+			  <li class="nav-item col col-6 col-md-auto" role="presentation">
+				<button class="nav-link w-100" id="pills-xcx-tab" data-bs-toggle="pill" data-bs-target="#pills-xcx" type="button" role="tab" aria-controls="pills-xcx" aria-selected="false"><img src="/images/xcx_icon.svg" width="32"/></button>
 			  </li>
-			  <li class="nav-item" role="presentation">
-				<button class="nav-link" id="pills-xc2-tab" data-bs-toggle="pill" data-bs-target="#pills-xc2" type="button" role="tab" aria-controls="pills-xc2" aria-selected="false"><img src="/images/xc2_icon.svg" width="32"/></button>
+			  <li class="nav-item col col-6 col-md-auto" role="presentation">
+				<button class="nav-link w-100" id="pills-xc2-tab" data-bs-toggle="pill" data-bs-target="#pills-xc2" type="button" role="tab" aria-controls="pills-xc2" aria-selected="false"><img src="/images/xc2_icon.svg" width="32"/></button>
 			  </li>
-			  <li class="nav-item" role="presentation">
-				<button class="nav-link" id="pills-xc3-tab" data-bs-toggle="pill" data-bs-target="#pills-xc3" type="button" role="tab" aria-controls="pills-xc3" aria-selected="false"><img src="/images/xc3_icon.svg" width="32"/></button>
+			  <li class="nav-item col col-6 col-md-auto" role="presentation">
+				<button class="nav-link w-100" id="pills-xc3-tab" data-bs-toggle="pill" data-bs-target="#pills-xc3" type="button" role="tab" aria-controls="pills-xc3" aria-selected="false"><img src="/images/xc3_icon.svg" width="32"/></button>
 			  </li>
-			  <li class="nav-item" role="presentation">
-				<button class="nav-link" id="pills-tools-tab" data-bs-toggle="pill" data-bs-target="#pills-tools" type="button" role="tab" aria-controls="pills-tools" aria-selected="false"><h5 class="text-white">Tools</h3></button>
+			  <li class="nav-item col col-6 col-md-auto" role="presentation">
+				<button class="nav-link w-100" id="pills-tools-tab" data-bs-toggle="pill" data-bs-target="#pills-tools" type="button" role="tab" aria-controls="pills-tools" aria-selected="false"><h5 class="text-white">Tools</h3></button>
 			  </li>
-			  <li class="nav-item" role="presentation">
-				<button class="nav-link" id="pills-links-tab" data-bs-toggle="pill" data-bs-target="#pills-links" type="button" role="tab" aria-controls="pills-links" aria-selected="false"><h5 class="text-white">Useful links</h3></button>
+			  <li class="nav-item col col-6 col-md-auto" role="presentation">
+				<button class="nav-link w-100" id="pills-links-tab" data-bs-toggle="pill" data-bs-target="#pills-links" type="button" role="tab" aria-controls="pills-links" aria-selected="false"><h5 class="text-white">Useful links</h3></button>
 			  </li>
 			</ul>
 		</div>

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 				<div class="h-100 p-5 rounded-3">
 					<img class="d-block mx-auto mb-4 img-fluid" src="/images/XC1_logo_small.png">
 					<div class="d-flex justify-content-center row text-center">
-						<div class="col-md-3 mt-2">
+						<div class="col-md-4 col-lg-3 mt-2">
 							<div class="card text-white card-bg card-height">
 								<div class="card-body">
 									<h4 class="card-title">Xenoblade 1 Data</h4>
@@ -100,7 +100,7 @@
 								</div>
 							</div>
 						</div>
-						<div class="col-md-3 mt-2">
+						<div class="col-md-4 col-lg-3 mt-2">
 							<div class="card text-white card-bg card-height">
 								<div class="card-body">
 									<h4 class="card-title">Definitive Edition Data</h4>
@@ -113,7 +113,7 @@
 								</div>
 							</div>
 						</div>
-						<div class="col-md-3 mt-2">
+						<div class="col-md-4 col-lg-3 mt-2">
 							<div class="card text-white card-bg card-height">
 								<div class="card-body">
 									<h4 class="card-title">Xenoblade 1 PKH file contents</h4>
@@ -127,7 +127,7 @@
 								</div>
 							</div>
 						</div>
-						<div class="col-md-3 mt-2">
+						<div class="col-md-4 col-lg-3 mt-2">
 							<div class="card text-white card-bg card-height">
 								<div class="card-body">
 									<h4 class="card-title">Xenoblade DE Audio Mapping data<br/>(🇬🇧 English / 🇯🇵 日本語)</h4>
@@ -173,7 +173,7 @@
 				<div class="h-100 p-2 rounded-3 text-center">
 					<img class="d-block mx-auto mb-4 img-fluid" src="/images/XC3_logo_small.png">
 					<div class="d-flex justify-content-center row">
-						<div class="col-md-3 mt-2">
+						<div class="col-md-4 col-lg-3 mt-2">
 							<div class="card text-white card-bg card-height">
 								<div class="card-body">
 									<h4 class="card-title">Xenoblade 3 1.2.1 + DLC2 Data</h4>
@@ -187,7 +187,7 @@
 								</div>
 							</div>
 						</div>
-						<div class="col-md-3 mt-2">
+						<div class="col-md-4 col-lg-3 mt-2">
 							<div class="card text-white card-bg card-height">
 								<div class="card-body">
 									<h4 class="card-title">Xenoblade 3 1.3.0 Data*</h4>
@@ -201,7 +201,7 @@
 								</div>
 							</div>
 						</div>
-						<div class="col-md-3 mt-2">
+						<div class="col-md-4 col-lg-3 mt-2">
 							<div class="card text-white card-bg card-height">
 								<div class="card-body">
 									<h4 class="card-title">Xenoblade 3 DLC3 Data*</h4>
@@ -215,7 +215,7 @@
 								</div>
 							</div>
 						</div>
-						<div class="col-md-3 mt-2">
+						<div class="col-md-4 col-lg-3 mt-2">
 							<div class="card text-white card-bg card-height">
 								<div class="card-body">
 									<h4 class="card-title">Xenoblade 3 2.0.0 + DLC 1-3 + Future Redeemed Data</h4>
@@ -231,7 +231,7 @@
 						</div>
 					</div>
 					<div class="d-flex justify-content-center row">
-						<div class="col-md-3 mt-2">
+						<div class="col-md-4 col-lg-3 mt-2">
 							<div class="card text-white card-bg card-height">
 								<div class="card-body">
 									<h4 class="card-title">Xenoblade 3 Audio Mapping data<br/>(🇬🇧 English / 🇯🇵 日本語)</h4>
@@ -245,7 +245,7 @@
 								</div>
 							</div>
 						</div>
-						<div class="col-md-3 mt-2">
+						<div class="col-md-4 col-lg-3 mt-2">
 							<div class="card text-white card-bg card-height">
 								<div class="card-body">
 									<h4 class="card-title">Xenoblade 3 BDAT hashes</h4>
@@ -270,7 +270,7 @@
 			<div class="text-center">
 				<h3>General purpose file manipulation tools</h3>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">XbTool</h5>
@@ -286,7 +286,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">XenoLib/XenobladeToolset</h5>
@@ -302,7 +302,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">QuickBMS</h5>
@@ -318,7 +318,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">SimpleDimple</h5>
@@ -337,7 +337,7 @@
 					</div>
 				</div>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">SAR.bms</h5>
@@ -353,7 +353,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Nenkai's XenoTools</h5>
@@ -369,7 +369,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Recordkeeper</h5>
@@ -389,7 +389,7 @@
 				<hr>
 				<h3>Data table tools</h3>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">bdat-rs</h5>
@@ -406,7 +406,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">xb3tool</h5>
@@ -422,7 +422,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">xc3_data_sheet</h5>
@@ -442,7 +442,7 @@
 				<hr>
 				<h3>Model tools</h3>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Xenoblade Importer For Noesis</h5>
@@ -458,7 +458,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Xenoblade Shape Key Tool</h5>
@@ -474,7 +474,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Monado Forge</h5>
@@ -490,7 +490,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">XenoMax</h5>
@@ -511,7 +511,7 @@
 					</div>
 				</div>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">"Temp" texture viewer</h5>
@@ -527,7 +527,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">fmt_XC3_wimdo.py</h5>
@@ -547,7 +547,7 @@
 				<hr>
 				<h3>Mods</h3>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Xenomods</h5>
@@ -563,7 +563,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">xc3-file-loader</h5>
@@ -579,7 +579,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">xc3-difficulty-unlocker</h5>
@@ -601,7 +601,7 @@
 				<hr>
 				<h3>Developer resources</h3>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">xc3_lib</h5>
@@ -617,7 +617,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">imgui-xeno</h5>
@@ -633,7 +633,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">xc3_model_py</h5>
@@ -653,7 +653,7 @@
 				<hr>
 				<h3>Audio tools</h3>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">vgmstream</h5>
@@ -669,7 +669,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">WWISER</h5>
@@ -685,7 +685,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">xeno3_PCK.bms</h5>
@@ -705,7 +705,7 @@
 				<hr>
 				<h3>Legacy game tools</h3>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-1">
+					<div class="col-md-4 col-lg-3 mt-1">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Brresviewer</h5>
@@ -729,7 +729,7 @@
 				<h4>Useful links</h4>
 				<h3>Discord servers</h3>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-2">
+					<div class="col-md-4 col-lg-3 mt-2">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">World Tree Research Discord</h5>
@@ -745,7 +745,7 @@
 				<hr/>
 				<h3>Knowledge bases/wikis</h3>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-2">
+					<div class="col-md-4 col-lg-3 mt-2">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Alrest Wiki</h5>
@@ -757,7 +757,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-2">
+					<div class="col-md-4 col-lg-3 mt-2">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">The Cutting Room Floor's Xeno series category</h5>
@@ -769,7 +769,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-2">
+					<div class="col-md-4 col-lg-3 mt-2">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Xeno Series Wiki</h5>
@@ -781,7 +781,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-2">
+					<div class="col-md-4 col-lg-3 mt-2">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">xc2f - Xenoblade 2 file formats</h5>
@@ -795,7 +795,7 @@
 					</div>
 				</div>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-2">
+					<div class="col-md-4 col-lg-3 mt-2">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">RoccoDev's personal blog</h5>
@@ -807,7 +807,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-2">
+					<div class="col-md-4 col-lg-3 mt-2">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Nenkai's Xeno Docs</h5>
@@ -823,7 +823,7 @@
 				<hr/>
 				<h3>Databases/data lists</h3>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-2">
+					<div class="col-md-4 col-lg-3 mt-2">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Xenoblade 3 Model Database</h5>
@@ -835,7 +835,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-2">
+					<div class="col-md-4 col-lg-3 mt-2">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Xenoblade 3 Cutscene Database</h5>
@@ -847,7 +847,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-2">
+					<div class="col-md-4 col-lg-3 mt-2">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Xenoblade Chronicles 3 voice lines list</h5>
@@ -859,7 +859,7 @@
 							</div>
 						</div>
 					</div>
-					<div class="col-md-3 mt-2">
+					<div class="col-md-4 col-lg-3 mt-2">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">XC3 Enemy Compendium</h5>
@@ -873,7 +873,7 @@
 					</div>
 				</div>
 				<div class="d-flex justify-content-center row">
-					<div class="col-md-3 mt-2">
+					<div class="col-md-4 col-lg-3 mt-2">
 						<div class="card text-white card-bg card-height">
 							<div class="card-body">
 								<h5 class="card-title">Xenoblade 3 devxml spreadsheet</h5>


### PR DESCRIPTION
This makes the layout more responsive so it looks better on mobile displays. It makes the following changes:

- Adds a viewport `meta` tag to adjust the initial scale
- Replaces some flex layouts with responsive grids
- Adjust some existing grid configurations for the new scale on medium displays

On an iPhone 12/13 mini:

Before:
![immagine](https://github.com/xenobladedata/xenobladedata.github.io/assets/13873938/99218c51-64a8-4af9-b762-793bcdde174a)

After:
![Schermata 2024-02-11 alle 17 14 53](https://github.com/xenobladedata/xenobladedata.github.io/assets/13873938/1ccc4374-d213-4dcf-8236-a865a9a16e79)

On an iPad:

Before (the preview makes it look bigger than it is, it was a bit hard to read):
![ipad_bef](https://github.com/xenobladedata/xenobladedata.github.io/assets/13873938/2967edc4-8fd7-4ce3-a727-5b8c6db7da51)

After:
![ipad_after](https://github.com/xenobladedata/xenobladedata.github.io/assets/13873938/192406a8-ee39-438c-88e0-7241db43d014)
